### PR TITLE
strip path from command

### DIFF
--- a/lib/puppet/provider/alternatives/dpkg.rb
+++ b/lib/puppet/provider/alternatives/dpkg.rb
@@ -1,6 +1,6 @@
 Puppet::Type.type(:alternatives).provide(:dpkg) do
 
-  commands :update => '/usr/sbin/update-alternatives'
+  commands :update => 'update-alternatives'
 
   has_feature :mode
 


### PR DESCRIPTION
newer versions of Debian and Ubuntu have the command in /usr/bin
