### PR TITLE
run of 'puppet resource alternative_entry' fails

### DIFF
--- a/lib/puppet/provider/alternative_entry/dpkg.rb
+++ b/lib/puppet/provider/alternative_entry/dpkg.rb
@@ -13,7 +13,11 @@ Puppet::Type.type(:alternative_entry).provide(:dpkg) do
   end
 
   def exists?
-    output = update('--list', @resource.value(:altname))
+    # we cannot fetch @resource.value(:altname) if running 'puppet resource alternative_entry'
+    temp_altname = altname
+    temp_altname = @resource.value(:altname) if @resource.value(:altname)
+
+    output = update('--list', temp_altname)
 
     output.split(/\n/).map(&:strip).any? do |line|
       line == @resource.value(:name)


### PR DESCRIPTION
Problem is there is no @resource when running puppet resource alternative_entry from a CLI. Puppet then doesn't know about resources but only inspects local system. This solves the issue for both cases (resource or system inspection).
