### PR TITLE
prefetch existing resources from system

### DIFF
--- a/lib/puppet/provider/alternative_entry/dpkg.rb
+++ b/lib/puppet/provider/alternative_entry/dpkg.rb
@@ -44,6 +44,14 @@ Puppet::Type.type(:alternative_entry).provide(:dpkg) do
 
     entries
   end
+  
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
 
   ALT_QUERY_REGEX = %r[Alternative: (.*?)$.Priority: (.*?)$]m
 


### PR DESCRIPTION
prefetch will, which given a list of resources, in one call return a set of provider instances filled with the value fetched from the real resource

http://www.masterzen.fr/2011/11/02/puppet-extension-point-part-2/
