### PR TITLE
Ubuntu seems to have moved update-alternatives to /usr/bin in 14.04

### DIFF
--- a/lib/puppet/provider/alternative_entry/dpkg.rb
+++ b/lib/puppet/provider/alternative_entry/dpkg.rb
@@ -3,7 +3,7 @@ Puppet::Type.type(:alternative_entry).provide(:dpkg) do
   confine :osfamily => 'Debian'
   defaultfor :operatingsystem => [:debian, :ubuntu]
 
-  commands :update  => '/usr/sbin/update-alternatives'
+  commands :update => 'update-alternatives'
   
   mk_resource_methods
 


### PR DESCRIPTION
In ubuntu 14.04 update-alternatives lives in /usr/bin. Removing the absolute path lets puppet find it in $PATH.
