### PR TITLE
Enable explicitly setting mode property to manual

### DIFF
--- a/lib/puppet/provider/alternatives/dpkg.rb
+++ b/lib/puppet/provider/alternatives/dpkg.rb
@@ -57,8 +57,14 @@ Puppet::Type.type(:alternatives).provide(:dpkg) do
     end
   end
 
-  # Set the mode to auto.
-  def mode=(_)
-    update('--auto', @resource.value(:name))
+  # Set the mode to manual or auto.
+  # @param [Symbol] newmode Either :auto or :manual for the alternatives mode
+  def mode=(newmode)
+    if newmode == :auto
+      update('--auto', @resource.value(:name))
+    elsif newmode == :manual
+      # No change in value, but sets it to manual
+      update('--set', name, path)
+    end
   end
 end

--- a/spec/unit/provider/alternatives/dpkg_spec.rb
+++ b/spec/unit/provider/alternatives/dpkg_spec.rb
@@ -63,5 +63,16 @@ describe Puppet::Type.type(:alternatives).provider(:dpkg) do
       subject.expects(:update).with('--set', 'editor', '/bin/nano')
       subject.path = '/bin/nano'
     end
+
+    it "#mode=(:auto) calls update-alternatives --auto" do
+      subject.expects(:update).with('--auto', 'editor')
+      subject.mode = :auto
+    end
+
+    it "#mode=(:manual) calls update-alternatives --set with current value" do
+      subject.expects(:path).returns('/usr/bin/vim.tiny')
+      subject.expects(:update).with('--set', 'editor', '/usr/bin/vim.tiny')
+      subject.mode = :manual
+    end
   end
 end


### PR DESCRIPTION
Use update-alternatives --set to change the value of the link to the current
value to ensure the alternative is set in "manual" mode.

This fixes a couple of issues:
- setting a path and mode => 'manual' would previously cause the mode to
  change to manual when the path was changed, but mode=(:manual) would be
  called which blindly called update-alternatives --auto
- allows the mode to be forced into manual without actively changing the
  value of the link, preventing it being automatically changed later
