### PR TITLE
Return 'false' from the alternative_entry entry? method.

### DIFF
--- a/lib/puppet/provider/alternative_entry/dpkg.rb
+++ b/lib/puppet/provider/alternative_entry/dpkg.rb
@@ -18,7 +18,11 @@ Puppet::Type.type(:alternative_entry).provide(:dpkg) do
 
   def exists?
     # we cannot fetch @resource.value(:altname) if running 'puppet resource alternative_entry'
-    output = update('--list', @resource.value(:altname) || altname)
+    begin
+      output = update('--list', @resource.value(:altname) || altname)
+    rescue
+      return false
+    end
 
     output.split(/\n/).map(&:strip).any? do |line|
       line == @resource.value(:name)


### PR DESCRIPTION
Without this, it fails to know that there is no setting at all for the
designated alternative, and bails out.
