### PR TITLE
Resolved issue preventing new alternative_entry from being created

### DIFF
--- a/lib/puppet/provider/alternative_entry/rpm.rb
+++ b/lib/puppet/provider/alternative_entry/rpm.rb
@@ -26,7 +26,11 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
   end
 
   def destroy
-    alternatives('--remove', @resource.value(:altname), @resource.value(:name)) if File.exists?('/var/lib/alternatives/' + @resource.value(:altname))
+    begin
+        alternatives('--remove', @resource.value(:altname), @resource.value(:name)) if File.exists?('/var/lib/alternatives/' + @resource.value(:altname))
+    rescue
+        puts "Alternative does not already exist."
+    end
   end
 
   def self.instances


### PR DESCRIPTION
Resolved issue preventing new alternative_entry from being created when altname exists but path does not. Refer to https://github.com/puppet-community/puppet-alternatives/issues/18

Adding exception handling in destroy prevents Puppet from exiting the rpm provider when the path in question does not exist.