### PR TITLE
Update rpm provider to include AWS Linux

### DIFF
--- a/lib/puppet/provider/alternatives/rpm.rb
+++ b/lib/puppet/provider/alternatives/rpm.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:alternatives).provide(:rpm) do
 
-  confine    :osfamily => :redhat
-  defaultfor :osfamily => :redhat
+  confine    :osfamily => [:redhat, :linux]
+  defaultfor :osfamily => [:redhat, :linux]
 
   commands :alternatives => '/usr/sbin/alternatives'
 


### PR DESCRIPTION
The specification of Linux osfamily may be too general,
but this will have to get fixed as support for more operating
systems is added.  Here are some results to use:

Debian:
$ facter | egrep operatingsystem\|osfamily
operatingsystem => Debian
operatingsystemrelease => 7.8
osfamily => Debian

AWS Linux:
$ facter | egrep operatingsystem\|osfamily
operatingsystem => Amazon
operatingsystemrelease => 3.14.44-32.39.amzn1.x86_64
osfamily => Linux

Issue: puppet-community/puppet-alternatives#25