### PR TITLE
new alternative_entry with rpm provider - fix

### DIFF
--- a/lib/puppet/provider/alternative_entry/rpm.rb
+++ b/lib/puppet/provider/alternative_entry/rpm.rb
@@ -24,7 +24,10 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
   end
 
   def destroy
-    alternatives('--remove', @resource.value(:altname), @resource.value(:name)) if File.exist?('/var/lib/alternatives/' + @resource.value(:altname))
+    begin
+      alternatives('--remove', @resource.value(:altname), @resource.value(:name))
+    rescue
+    end
   end
 
   def self.instances

--- a/lib/puppet/provider/alternative_entry/rpm.rb
+++ b/lib/puppet/provider/alternative_entry/rpm.rb
@@ -24,9 +24,13 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
   end
 
   def destroy
+    # rubocop:disable Style/RedundantBegin
     begin
+      # rubocop::enable Style/RedundantBegin
       alternatives('--remove', @resource.value(:altname), @resource.value(:name))
+      # rubocop:disable Lint/HandleExceptions
     rescue
+      # rubocop:enable Lint/HandleExceptions
     end
   end
 

--- a/spec/unit/provider/alternatives/rpm_spec.rb
+++ b/spec/unit/provider/alternatives/rpm_spec.rb
@@ -46,6 +46,5 @@ describe Puppet::Type.type(:alternatives).provider(:rpm) do
       subject.expects(:alternatives).with('--set', 'editor', '/bin/nano')
       subject.path = '/bin/nano'
     end
-
   end
 end

--- a/spec/unit/provider/alternatives/rpm_spec.rb
+++ b/spec/unit/provider/alternatives/rpm_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:alternatives).provider(:rpm) do
+  def my_fixture(path)
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'provider', 'alternatives', 'rpm', path)
+  end
+
+  def my_fixture_read(path)
+    File.read(my_fixture(path))
+  end
+
+  let(:stub_selections) do
+    {
+      'editor' => { :mode => 'manual', :path => '/usr/bin/vim.tiny' },
+      'mta'    => { :mode => 'manual', :path => '/usr/sbin/sendmail' },
+    }
+  end
+
+  describe '.all' do
+  end
+
+  describe '.instances' do
+    it 'delegates to .all' do
+      described_class.expects(:all).returns(stub_selections)
+      described_class.expects(:new).twice.returns(stub)
+      described_class.instances
+    end
+  end
+
+  describe 'instances' do
+    subject { described_class.new(:name => 'editor') }
+
+    let(:resource) { Puppet::Type.type(:alternatives).new(:name => 'editor') }
+
+    before do
+      Puppet::Type.type(:alternatives).stubs(:defaultprovider).returns described_class
+      resource.provider = subject
+      described_class.stubs(:all).returns(stub_selections)
+    end
+
+    it '#path retrieves the path from class.all' do
+      expect(subject.path).to eq('/usr/bin/vim.tiny')
+    end
+
+    it '#path= updates the path with update-alternatives --set' do
+      subject.expects(:alternatives).with('--set', 'editor', '/bin/nano')
+      subject.path = '/bin/nano'
+    end
+
+  end
+end


### PR DESCRIPTION
the provider throws an eror when used on an alternative_entry which is
not yet present.
this code does not throw an error neither does it do puppet notice.

+ added rpm provider spec tests on alternatives resource type

fixes #18 