### PR TITLE
Bugfix/alternative entry

### DIFF
--- a/lib/puppet/provider/alternative_entry/rpm.rb
+++ b/lib/puppet/provider/alternative_entry/rpm.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
     end
   end
 
-  ALT_RPM_QUERY_REGEX = %r{ link currently points to (.*?)$.* - priority (.*?)$}m
+  ALT_RPM_QUERY_REGEX = %r|^(.*\/[^\/]*) - priority (\w+)$|
 
   def self.query_alternative(altname)
     output = alternatives('--display', altname)

--- a/lib/puppet/provider/alternative_entry/rpm.rb
+++ b/lib/puppet/provider/alternative_entry/rpm.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
     end
   end
 
-  ALT_RPM_QUERY_REGEX = %r|^(.*\/[^\/]*) - priority (\w+)$|
+  ALT_RPM_QUERY_REGEX = %r{^(.*\/[^\/]*) - priority (\w+)$}
 
   def self.query_alternative(altname)
     output = alternatives('--display', altname)

--- a/lib/puppet/provider/alternative_entry/rpm.rb
+++ b/lib/puppet/provider/alternative_entry/rpm.rb
@@ -2,16 +2,16 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
   confine osfamily: :redhat
   defaultfor osfamily: :redhat
 
-  commands alternatives: '/usr/sbin/alternatives'
+  commands update: '/usr/sbin/alternatives'
 
   mk_resource_methods
 
   def create
-    alternatives('--install',
-                 @resource.value(:altlink),
-                 @resource.value(:altname),
-                 @resource.value(:name),
-                 @resource.value(:priority))
+    update('--install',
+           @resource.value(:altlink),
+           @resource.value(:altname),
+           @resource.value(:name),
+           @resource.value(:priority))
   end
 
   def exists?
@@ -26,7 +26,7 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
     # rubocop:disable Style/RedundantBegin
     begin
       # rubocop::enable Style/RedundantBegin
-      alternatives('--remove', @resource.value(:altname), @resource.value(:name))
+      update('--remove', @resource.value(:altname), @resource.value(:name))
       # rubocop:disable Lint/HandleExceptions
     rescue
       # rubocop:enable Lint/HandleExceptions
@@ -60,10 +60,9 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
   ALT_RPM_QUERY_REGEX = %r{^(.*\/[^\/]*) - priority (\w+)$}
 
   def self.query_alternative(altname)
-    output = alternatives('--display', altname)
-
+    output = update('--display', altname)
+    altlink = File.readlines('/var/lib/alternatives/' + altname)[1].chomp
     output.scan(ALT_RPM_QUERY_REGEX).map do |(path, priority)|
-      altlink = File.readlines('/var/lib/alternatives/' + altname)[1].chomp
       { altname: altname, altlink: altlink, name: path, priority: priority }
     end
   end

--- a/lib/puppet/provider/alternatives/rpm.rb
+++ b/lib/puppet/provider/alternatives/rpm.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:alternatives).provide(:rpm) do
   #
   # @return [Hash<String, Hash<Symbol, String>>]
   def self.all
-    hash = Hash.new()
+    hash = {}
     list_alternatives.map { |x| File.basename(x) }.each do |name|
       # rubocop:enable Style/EachWithObject
       output = update('--display', name)

--- a/spec/fixtures/unit/provider/alternatives/rpm/alternatives/sample
+++ b/spec/fixtures/unit/provider/alternatives/rpm/alternatives/sample
@@ -1,0 +1,9 @@
+manual
+/usr/bin/sample
+
+/opt/sample1
+10
+/opt/sample2
+20
+/opt/sample3
+30

--- a/spec/fixtures/unit/provider/alternatives/rpm/alternatives/testcmd
+++ b/spec/fixtures/unit/provider/alternatives/rpm/alternatives/testcmd
@@ -1,0 +1,7 @@
+manual
+/usr/bin/testcmd
+
+/opt/testcmd1
+10
+/opt/testcmd2
+20

--- a/spec/fixtures/unit/provider/alternatives/rpm/display/sample
+++ b/spec/fixtures/unit/provider/alternatives/rpm/display/sample
@@ -1,0 +1,5 @@
+sample - status is manual.
+ link currently points to /opt/sample2
+/opt/sample1 - priority 10
+/opt/sample2 - priority 20
+Current `best' version is /opt/sample2.

--- a/spec/fixtures/unit/provider/alternatives/rpm/display/testcmd
+++ b/spec/fixtures/unit/provider/alternatives/rpm/display/testcmd
@@ -1,0 +1,5 @@
+testcmd - status is manual.
+ link currently points to /opt/testcmd1
+/opt/testcmd1 - priority 10
+/opt/testcmd2 - priority 20
+Current `best' version is /opt/testcmd2.

--- a/spec/unit/provider/alternatives/rpm_spec.rb
+++ b/spec/unit/provider/alternatives/rpm_spec.rb
@@ -15,8 +15,8 @@ describe Puppet::Type.type(:alternatives).provider(:rpm) do
 
   let(:stub_selections) do
     {
-        'sample'   => { path: '/opt/sample1' },
-        'testcmd'  => { path: '/opt/testcmd1' },
+      'sample'  => { path: '/opt/sample1' },
+      'testcmd' => { path: '/opt/testcmd1' }
     }
   end
 

--- a/spec/unit/provider/alternatives/rpm_spec.rb
+++ b/spec/unit/provider/alternatives/rpm_spec.rb
@@ -1,19 +1,46 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:alternatives).provider(:rpm) do
-  def my_fixture(path)
-    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'provider', 'alternatives', 'rpm', path)
+  def my_fixture_alternatives
+    Dir.glob(File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'provider', 'alternatives', 'rpm', 'alternatives', '*'))
   end
 
-  def my_fixture_read(path)
-    File.read(my_fixture(path))
+  def my_fixture_display(type, path)
+    File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'provider', 'alternatives', 'rpm', type, path)
+  end
+
+  def my_fixture_read(type, path)
+    File.read(my_fixture_display(type, path))
   end
 
   let(:stub_selections) do
     {
-      'editor' => { mode: 'manual', path: '/usr/bin/vim.tiny' },
-      'mta'    => { mode: 'manual', path: '/usr/sbin/sendmail' }
+        'sample'   => { path: '/opt/sample1' },
+        'testcmd'  => { path: '/opt/testcmd1' },
     }
+  end
+
+  describe '.all' do
+    it 'List all alternatives in folder /var/lib/alternatives' do
+      described_class.expects(:list_alternatives).returns my_fixture_alternatives
+      described_class.expects(:update).with('--display', 'sample').returns my_fixture_read('display', 'sample')
+      described_class.expects(:update).with('--display', 'testcmd').returns my_fixture_read('display', 'testcmd')
+      described_class.all
+    end
+
+    describe 'returning data' do
+      before do
+        described_class.stubs(:list_alternatives).returns my_fixture_alternatives
+        described_class.stubs(:update).with('--display', 'sample').returns my_fixture_read('display', 'sample')
+        described_class.stubs(:update).with('--display', 'testcmd').returns my_fixture_read('display', 'testcmd')
+      end
+
+      subject { described_class.all }
+
+      it { is_expected.to be_a Hash }
+      it { expect(subject['sample']).to eq(mode: 'manual', path: '/opt/sample2') }
+      it { expect(subject['testcmd']).to eq(mode: 'manual', path: '/opt/testcmd1') }
+    end
   end
 
   describe '.instances' do
@@ -25,23 +52,36 @@ describe Puppet::Type.type(:alternatives).provider(:rpm) do
   end
 
   describe 'instances' do
-    subject { described_class.new(name: 'editor') }
+    subject { described_class.new(name: 'sample') }
 
-    let(:resource) { Puppet::Type.type(:alternatives).new(name: 'editor') }
+    let(:resource) { Puppet::Type.type(:alternatives).new(name: 'sample') }
 
     before do
       Puppet::Type.type(:alternatives).stubs(:defaultprovider).returns described_class
+      described_class.stubs(:update).with('--display', 'sample').returns my_fixture_read('display', 'sample')
+      described_class.stubs(:update).with('--display', 'testcmd').returns my_fixture_read('display', 'testcmd')
       resource.provider = subject
       described_class.stubs(:all).returns(stub_selections)
     end
 
     it '#path retrieves the path from class.all' do
-      expect(subject.path).to eq('/usr/bin/vim.tiny')
+      expect(subject.path).to eq('/opt/sample1')
     end
 
-    it '#path= updates the path with update-alternatives --set' do
-      subject.expects(:alternatives).with('--set', 'editor', '/bin/nano')
-      subject.path = '/bin/nano'
+    it '#path= updates the path with alternatives --set' do
+      subject.expects(:update).with('--set', 'sample', '/opt/sample1')
+      subject.path = '/opt/sample1'
+    end
+
+    it '#mode=(:auto) calls alternatives --auto' do
+      subject.expects(:update).with('--auto', 'sample')
+      subject.mode = :auto
+    end
+
+    it '#mode=(:manual) calls alternatives --set with current value' do
+      subject.expects(:path).returns('/opt/sample2')
+      subject.expects(:update).with('--set', 'sample', '/opt/sample2')
+      subject.mode = :manual
     end
   end
 end


### PR DESCRIPTION
The ALT_RPM_QUERY_REGEX was only catching the default entry which causes the resources to be appied again and again if multiple alternative_entry in the manifest.

eg : 

with 

``` puppet
alternative_entry { "/usr/java/jdk1.7.0_67/bin/java":
  ensure   => present,
  altlink  => '/usr/bin/java',
  altname  => 'java',
  priority => '17067'
}
```

the regex ALT_RPM_QUERY_REGEX (`%r{ link currently points to (.*?)$.* - priority (.*?)$}m`) is therefor correct.

With

``` puppet
alternative_entry { "/usr/java/jdk1.7.0_67/bin/java":
  ensure   => present,
  altlink  => '/usr/bin/java',
  altname  => 'java',
  priority => '17067'
}

alternative_entry { "/usr/java/jdk1.8.0_102/bin/java":
  ensure   => present,
  altlink  => '/usr/bin/java',
  altname  => 'java',
  priority => '18102'
}
```

``` bash
[17:25:47] root@testhost:~ # puppet apply --test testmanifest.pp
Info: Loading facts
Info: Loading facts
Notice: Compiled catalog for testhost.local in environment production in 0.53 seconds
Info: Applying configuration version '1477063555'
Notice: /Stage[main]/Main/Alternative_entry[/usr/java/jdk1.8.0_102/bin/java]/altlink: defined 'altlink' as '/usr/bin/java'
Notice: /Stage[main]/Main/Alternative_entry[/usr/java/jdk1.8.0_102/bin/java]/altname: defined 'altname' as 'java'
Notice: /Stage[main]/Main/Alternative_entry[/usr/java/jdk1.8.0_102/bin/java]/priority: defined 'priority' as '18102'
Notice: Finished catalog run in 0.61 seconds
[17:25:58] root@testhost:~ # puppet apply --test testmanifest.pp
Info: Loading facts
Info: Loading facts
Notice: Compiled catalog for testhost.local in environment production in 0.55 seconds
Info: Applying configuration version '1477063564'
Notice: /Stage[main]/Main/Alternative_entry[/usr/java/jdk1.8.0_102/bin/java]/altlink: defined 'altlink' as '/usr/bin/java'
Notice: /Stage[main]/Main/Alternative_entry[/usr/java/jdk1.8.0_102/bin/java]/altname: defined 'altname' as 'java'
Notice: /Stage[main]/Main/Alternative_entry[/usr/java/jdk1.8.0_102/bin/java]/priority: defined 'priority' as '18102'
Notice: /Stage[main]/Main/Alternative_entry[/usr/java/jdk1.7.0_67/bin/java]/priority: priority changed '18102' to '17067'
Notice: /Stage[main]/Main/Alternatives[java]/path: path changed '/usr/java/jdk1.8.0_102/bin/java' to '/usr/java/jdk1.7.0_67/bin/java'
Notice: Finished catalog run in 0.64 seconds
[17:26:06] root@testhost:~ # 
```

the second entry is never caught and applied at every run.

Correcting the Regex to catch all the entries in the /var/lib/alternatives/#{altname} will fix the issue.

``` bash
[17:25:58] root@testhost:~ # puppet apply --test testmanifest.pp
Info: Loading facts
Info: Loading facts
Notice: Compiled catalog for testhost.local in environment production in 0.09 seconds
Info: Applying configuration version '1477063824'
Notice: Finished catalog run in 0.67 seconds
[17:26:06] root@testhost:~ # 
```

regards.
