### PR TITLE
Added namevar to altlink to create a composite namevar name:altlink.

### DIFF
--- a/lib/puppet/provider/alternative_entry/dpkg.rb
+++ b/lib/puppet/provider/alternative_entry/dpkg.rb
@@ -47,11 +47,13 @@ Puppet::Type.type(:alternative_entry).provide(:dpkg) do
   end
 
   def self.prefetch(resources)
+    catalog = resources.values.first.catalog
     instances.each do |prov|
       # rubocop:disable Lint/AssignmentInCondition
-      if resource = resources[prov.name]
-        # rubocop:enable Lint/AssignmentInCondition
-        resource.provider = prov
+      catalog.resources.each do |item|
+        if item.class.to_s == 'Puppet::Type::Alternative_entry' && item.name == prov.name && item.parameter('altlink').value == prov.altlink
+          item.provider = prov
+        end
       end
     end
   end
@@ -64,7 +66,7 @@ Puppet::Type.type(:alternative_entry).provide(:dpkg) do
     altlink = output.match(%r{Link: (.*)$})[1]
 
     output.scan(ALT_QUERY_REGEX).map do |(path, priority)|
-      { altname: altname, altlink: altlink, name: path, priority: priority }
+      { altname: altname, altlink: altlink, name: path, priority: priority,  }
     end
   end
 

--- a/lib/puppet/provider/alternative_entry/dpkg.rb
+++ b/lib/puppet/provider/alternative_entry/dpkg.rb
@@ -49,7 +49,6 @@ Puppet::Type.type(:alternative_entry).provide(:dpkg) do
   def self.prefetch(resources)
     catalog = resources.values.first.catalog
     instances.each do |prov|
-      # rubocop:disable Lint/AssignmentInCondition
       catalog.resources.each do |item|
         if item.class.to_s == 'Puppet::Type::Alternative_entry' && item.name == prov.name && item.parameter('altlink').value == prov.altlink
           item.provider = prov
@@ -66,7 +65,7 @@ Puppet::Type.type(:alternative_entry).provide(:dpkg) do
     altlink = output.match(%r{Link: (.*)$})[1]
 
     output.scan(ALT_QUERY_REGEX).map do |(path, priority)|
-      { altname: altname, altlink: altlink, name: path, priority: priority,  }
+      { altname: altname, altlink: altlink, name: path, priority: priority }
     end
   end
 

--- a/lib/puppet/provider/alternative_entry/rpm.rb
+++ b/lib/puppet/provider/alternative_entry/rpm.rb
@@ -18,7 +18,6 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
     @property_hash[:ensure] == :present
   end
 
-
   def destroy
     # rubocop:disable Style/RedundantBegin
     begin
@@ -46,16 +45,13 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
   def self.prefetch(resources)
     catalog = resources.values.first.catalog
     instances.each do |prov|
-      # rubocop:disable Lint/AssignmentInCondition
       catalog.resources.each do |item|
         if item.class.to_s == 'Puppet::Type::Alternative_entry' && item.name == prov.name && item.parameter('altlink').value == prov.altlink
           item.provider = prov
         end
       end
-
     end
   end
-
 
   ALT_RPM_QUERY_REGEX = %r{^(.*\/[^\/]*) -.*priority (\w+)$}
 

--- a/lib/puppet/provider/alternative_entry/rpm.rb
+++ b/lib/puppet/provider/alternative_entry/rpm.rb
@@ -15,12 +15,9 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
   end
 
   def exists?
-    output = Dir.glob('/var/lib/alternatives/*').map { |x| File.basename(x) }
-
-    output.each do |altname|
-      altname == @resource.value(:name)
-    end
+    @property_hash[:ensure] == :present
   end
+
 
   def destroy
     # rubocop:disable Style/RedundantBegin
@@ -43,27 +40,30 @@ Puppet::Type.type(:alternative_entry).provide(:rpm) do
         entries << new(alt)
       end
     end
-
     entries
   end
 
   def self.prefetch(resources)
+    catalog = resources.values.first.catalog
     instances.each do |prov|
       # rubocop:disable Lint/AssignmentInCondition
-      if resource = resources[prov.name]
-        # rubocop:enable Lint/AssignmentInCondition
-        resource.provider = prov
+      catalog.resources.each do |item|
+        if item.class.to_s == 'Puppet::Type::Alternative_entry' && item.name == prov.name && item.parameter('altlink').value == prov.altlink
+          item.provider = prov
+        end
       end
+
     end
   end
 
-  ALT_RPM_QUERY_REGEX = %r{^(.*\/[^\/]*) - priority (\w+)$}
+
+  ALT_RPM_QUERY_REGEX = %r{^(.*\/[^\/]*) -.*priority (\w+)$}
 
   def self.query_alternative(altname)
     output = update('--display', altname)
     altlink = File.readlines('/var/lib/alternatives/' + altname)[1].chomp
     output.scan(ALT_RPM_QUERY_REGEX).map do |(path, priority)|
-      { altname: altname, altlink: altlink, name: path, priority: priority }
+      { altname: altname, altlink: altlink, name: path, priority: priority, altlink_ro: altlink, ensure: :present }
     end
   end
 

--- a/lib/puppet/type/alternative_entry.rb
+++ b/lib/puppet/type/alternative_entry.rb
@@ -1,16 +1,20 @@
 Puppet::Type.newtype(:alternative_entry) do
   ensurable
 
-  newparam(:name, isnamevar: true) do
+  newparam(:name) do
     desc 'The path to the actual alternative'
+
+    isnamevar
 
     validate do |path|
       raise ArgumentError, 'path must be a fully qualified path' unless absolute_path? path
     end
   end
 
-  newproperty(:altlink) do
+  newparam(:altlink) do
     desc 'The name of the generic symlink for this alternative entry'
+
+    isnamevar
 
     validate do |path|
       raise ArgumentError, 'path must be a fully qualified path' unless absolute_path? path
@@ -31,5 +35,30 @@ Puppet::Type.newtype(:alternative_entry) do
         raise ArgumentError, 'priority must be an integer'
       end
     end
+  end
+
+  def self.title_patterns
+    [
+      [
+        %r{^([^:]+)$},
+        [
+          [:name],
+        ],
+      ],
+      [
+        %r{^(.*):([a-z]:(/|\\).*)$}i,
+        [
+          [:name],
+          [:altlink],
+        ],
+      ],
+      [
+        %r{^(.*):(.*)$},
+        [
+          [:name],
+          [:altlink],
+        ],
+      ],
+    ]
   end
 end

--- a/lib/puppet/type/alternative_entry.rb
+++ b/lib/puppet/type/alternative_entry.rb
@@ -42,23 +42,23 @@ Puppet::Type.newtype(:alternative_entry) do
       [
         %r{^([^:]+)$},
         [
-          [:name],
-        ],
+          [:name]
+        ]
       ],
       [
         %r{^(.*):([a-z]:(/|\\).*)$}i,
         [
           [:name],
-          [:altlink],
-        ],
+          [:altlink]
+        ]
       ],
       [
         %r{^(.*):(.*)$},
         [
           [:name],
-          [:altlink],
-        ],
-      ],
+          [:altlink]
+        ]
+      ]
     ]
   end
 end

--- a/lib/puppet/type/alternative_entry.rb
+++ b/lib/puppet/type/alternative_entry.rb
@@ -21,9 +21,8 @@ Puppet::Type.newtype(:alternative_entry) do
     end
   end
 
-  newproperty(:altlink_ro, :readonly => true) do
+  newproperty(:altlink_ro, readonly: true) do
     desc 'The name of the generic symlink for this alternative entry as parameter. This is readonly.'
-
   end
 
   newproperty(:altname) do

--- a/lib/puppet/type/alternative_entry.rb
+++ b/lib/puppet/type/alternative_entry.rb
@@ -21,6 +21,11 @@ Puppet::Type.newtype(:alternative_entry) do
     end
   end
 
+  newproperty(:altlink_ro, :readonly => true) do
+    desc 'The name of the generic symlink for this alternative entry as parameter. This is readonly.'
+
+  end
+
   newproperty(:altname) do
     desc 'The name of symlink in the alternatives directory'
   end


### PR DESCRIPTION

#### Pull Request (PR) description
This allows the user to specify more than one alternative_entry for a binary by making the altlink parameter a namevar (composite namevar) as well. Additionally it introduces a title pattern, so that you can use a resource title of "<name>:<altname>" to specify both namevars in the title. If no colon is given, than the tittle pattern defaults to the old behavior of just mapping to the name.

I had to change the type of altlink to param because it seems that properties are not usable for composite namevars.

#### This Pull Request (PR) fixes the following issues

Fixes #40 
Fixes #41
