### PR TITLE
handle broken alternatives entries more gracefully

### DIFF
--- a/lib/puppet/provider/alternatives/rpm.rb
+++ b/lib/puppet/provider/alternatives/rpm.rb
@@ -27,11 +27,15 @@ Puppet::Type.type(:alternatives).provide(:rpm) do
   def self.all
     hash = {}
     list_alternatives.map { |x| File.basename(x) }.each do |name|
-      # rubocop:enable Style/EachWithObject
-      output = update('--display', name)
-      mode = output.match(ALT_RPM_QUERY_CURRENT_REGEX)[1]
-      path = output.match(ALT_RPM_QUERY_CURRENT_REGEX)[2]
-      hash[name] = { path: path, mode: mode }
+      begin
+        # rubocop:enable Style/EachWithObject
+        output = update('--display', name)
+        mode = output.match(ALT_RPM_QUERY_CURRENT_REGEX)[1]
+        path = output.match(ALT_RPM_QUERY_CURRENT_REGEX)[2]
+        hash[name] = { path: path, mode: mode }
+      rescue
+        Puppet.warning format(_('Failed to parse alternatives entry %{name}'), name: name)
+      end
     end
     hash
   end


### PR DESCRIPTION
#### Pull Request (PR) description
When using this provider on a RHEL/CentOS system where an alternatives entry is in a broken state, the provider will fail and the entire Puppet run is aborted:

```
Info: Applying configuration version '1551280298'
Error: Failed to apply catalog: Execution of '/usr/sbin/alternatives --display jar' returned 2: failed to read link /usr/bin/jar: No such file or directory
```

This pull requests adds some safekeeping when running `alternatives --display [name]` to ensure the provider keeps working even when a broken alternatives entry exists on the system (which is often the case). Broken alternatives entries are ignored as a result, but can finally be recreated by using this provider.

When a broken alternative entry is found (that means an instance where `alternatives --display [name]` exits with a exit code >0), the provider will issue a Puppet warning:

```
Warning: Failed to parse alternatives entry jar
```

#### This Pull Request (PR) fixes the following issues
Fixes #54