### PR TITLE
Allow family to be used instead of full path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # puppet-alternatives
 
-[![Build Status](https://travis-ci.org/voxpupuli/puppet-alternatives.png?branch=master)](https://travis-ci.org/voxpupuli/puppet-alternatives)
+[![Build Status](https://github.com/voxpupuli/puppet-alternatives/workflows/CI/badge.svg)](https://github.com/voxpupuli/puppet-alternatives/actions?query=workflow%3ACI)
 [![Code Coverage](https://coveralls.io/repos/github/voxpupuli/puppet-alternatives/badge.svg?branch=master)](https://coveralls.io/github/voxpupuli/puppet-alternatives)
 [![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/alternatives.svg)](https://forge.puppet.com/puppet/alternatives)
 [![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/alternatives.svg)](https://forge.puppet.com/puppet/alternatives)
@@ -54,35 +54,47 @@ Using `puppet resource` to update an alternative
 
 Using the alternatives resource in a manifest:
 
-    class ruby::193 {
+```puppet
+class ruby_193 {
 
-      package { 'ruby1.9.3':
-        ensure => present,
-      }
+  package { 'ruby1.9.3':
+    ensure => present,
+  }
 
-      # Will also update gem, irb, rdoc, rake, etc.
-      alternatives { 'ruby':
-        path    => '/usr/bin/ruby1.9.3',
-        require => Package['ruby1.9.3'],
-      }
-    }
+  # Will also update gem, irb, rdoc, rake, etc.
+  alternatives { 'ruby':
+    path    => '/usr/bin/ruby1.9.3',
+    require => Package['ruby1.9.3'],
+  }
+}
 
-    # magic!
-    include ruby::193
+include ruby_193
+```
 
 - - -
 
 Creating a new alternative entry:
 
-    alternative_entry {'/usr/bin/gcc-4.4':
-        ensure   => present,
-        altlink  => '/usr/bin/gcc',
-        altname  => 'gcc',
-        priority => 10,
-        require  => Package['gcc-4.4-multilib'],
-    }
+```puppet
+alternative_entry { '/usr/bin/gcc-4.4':
+  ensure   => present,
+  altlink  => '/usr/bin/gcc',
+  altname  => 'gcc',
+  priority => 10,
+  require  => Package['gcc-4.4-multilib'],
+}
+```
 
 - - -
+
+On RedHat, configuring an alternative using a family instead of a full path:
+
+```puppet
+alternatives { 'java':
+  path    => 'java-1.8.0-openjdk.x86_64',
+  require => Package['java-1.8.0-openjdk'],
+}
+```
 
 This module should work on any Debian and RHEL based distribution.
 

--- a/lib/puppet/provider/alternatives/chkconfig.rb
+++ b/lib/puppet/provider/alternatives/chkconfig.rb
@@ -33,10 +33,18 @@ Puppet::Type.type(:alternatives).provide(:chkconfig) do
       mode = output.match(ALT_RPM_QUERY_CURRENT_REGEX)[1]
       path = output.match(ALT_RPM_QUERY_CURRENT_REGEX)[2]
       hash[name] = { path: path, mode: mode }
+      if (matches = output.match(%r{^#{path} - family (.+) priority \d+$}))
+        hash[name][:family] = matches[1]
+      end
     rescue StandardError
       Puppet.warning format(_('Failed to parse alternatives entry %{name}'), name: name)
     end
     hash
+  end
+
+  def family
+    name = @resource.value(:name)
+    self.class.all[name][:family]
   end
 
   # Retrieve the current path link

--- a/lib/puppet/type/alternatives.rb
+++ b/lib/puppet/type/alternatives.rb
@@ -22,15 +22,14 @@ Puppet::Type.newtype(:alternatives) do
     newvalue('manual')
   end
 
-  # Turns out this isn't a valid hook.
-  # validate do
-  #  case self[:mode]
-  #  when 'auto'
-  #    raise ArgumentError, "Mode cannot be 'auto' if a path is given" if self[:path]
-  #  when 'manual'
-  #    raise ArgumentError, "Mode cannot be 'manual' without a path" unless self[:path]
-  #  end
-  # end
+  validate do
+    case self[:mode]
+    when :auto
+      raise Puppet::Error, "Mode cannot be 'auto' if a path is given" if self[:path]
+    when :manual
+      raise Puppet::Error, "Mode cannot be 'manual' without a path" unless self[:path]
+    end
+  end
 
   autorequire(:alternative_entry) do
     self[:path]

--- a/lib/puppet/type/alternatives.rb
+++ b/lib/puppet/type/alternatives.rb
@@ -8,10 +8,18 @@ Puppet::Type.newtype(:alternatives) do
   end
 
   newproperty(:path) do
-    desc 'The path of the desired source for the given alternative'
+    desc 'The path of the desired source for the given alternative. On RedHat, a family can be specified instead'
+
+    def insync?(is)
+      if absolute_path? should
+        is == should
+      else
+        provider.family == should
+      end
+    end
 
     validate do |path|
-      raise ArgumentError, 'path must be a fully qualified path' unless absolute_path? path
+      raise ArgumentError, 'path must be a fully qualified path' unless (absolute_path? path) || (Facter.value(:osfamily) == 'RedHat')
     end
   end
 

--- a/spec/acceptance/family_spec.rb
+++ b/spec/acceptance/family_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+if os[:family] == 'redhat'
+  describe 'setting alternatives with a `family`' do
+    context 'java 8' do
+      let(:pp) do
+        <<-PP
+        package { ['java-1.8.0-openjdk','java-11-openjdk']:
+          ensure => installed,
+          before => Alternatives['java'],
+        }
+
+        alternatives { 'java':
+          path => 'java-1.8.0-openjdk.x86_64',
+        }
+        PP
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      describe command('java -version') do
+        its(:stderr) { is_expected.to match %r{1\.8\.0} }
+      end
+    end
+
+    context 'java 11' do
+      let(:pp) do
+        <<-PP
+        package { ['java-1.8.0-openjdk','java-11-openjdk']:
+          ensure => installed,
+          before => Alternatives['java'],
+        }
+
+        alternatives { 'java':
+          path => 'java-11-openjdk.x86_64',
+        }
+        PP
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      describe command('java -version') do
+        its(:stderr) { is_expected.to match %r{11\.0} }
+      end
+    end
+  end
+end

--- a/spec/unit/type/alternatives_spec.rb
+++ b/spec/unit/type/alternatives_spec.rb
@@ -13,7 +13,7 @@ describe Puppet::Type.type(:alternatives) do
     end
   end
 
-  describe 'validating the mode', pending: 'Type level validation' do
+  describe 'validating the mode' do
     it 'raises an error if the mode is auto and a path is set' do
       expect do
         described_class.new(name: 'thing', mode: 'auto', path: '/usr/bin/explode')

--- a/spec/unit/type/alternatives_spec.rb
+++ b/spec/unit/type/alternatives_spec.rb
@@ -4,12 +4,32 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:alternatives) do
   describe 'property `path`' do
-    it 'passes validation with an absolute path' do
-      expect { described_class.new(name: 'ruby', path: '/usr/bin/ruby1.9') }.not_to raise_error
+    context 'on Debian systems' do
+      before do
+        Facter.stubs(:value).with(:osfamily).returns('Debian')
+      end
+
+      it 'passes validation with an absolute path' do
+        expect { described_class.new(name: 'ruby', path: '/usr/bin/ruby1.9') }.not_to raise_error
+      end
+
+      it 'fails validation without an absolute path' do
+        expect { described_class.new(name: 'ruby', path: "The bees they're in my eyes") }.to raise_error Puppet::Error, %r{must be a fully qualified path}
+      end
     end
 
-    it 'fails validation without an absolute path' do
-      expect { described_class.new(name: 'ruby', path: "The bees they're in my eyes") }.to raise_error Puppet::Error, %r{must be a fully qualified path}
+    context 'on RedHat systems' do
+      before do
+        Facter.stubs(:value).with(:osfamily).returns('RedHat')
+      end
+
+      it 'passes validation with an absolute path' do
+        expect { described_class.new(name: 'java', path: '/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.342.b07-1.el7_9.x86_64/jre/bin/java') }.not_to raise_error
+      end
+
+      it 'fails validation without an absolute path' do
+        expect { described_class.new(name: 'java', path: 'java-1.8.0-openjdk.x86_64') }.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
This only works on RedHat family operating systems.

Fixes #71