### PR TITLE
Drop EoL Debian 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@
 
 name: CI
 
+# yamllint disable-line rule:truthy
 on:
   pull_request: {}
   push:
@@ -18,4 +19,4 @@ concurrency:
 jobs:
   puppet:
     name: Puppet
-    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v3

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@
 
 name: "Pull Request Labeler"
 
+# yamllint disable-line rule:truthy
 on:
   pull_request_target: {}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@
 
 name: Release
 
+# yamllint disable-line rule:truthy
 on:
   push:
     tags:
@@ -12,7 +13,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: voxpupuli/gha-puppet/.github/workflows/release.yml@v2
+    uses: voxpupuli/gha-puppet/.github/workflows/release.yml@v3
     with:
       allowed_owner: 'voxpupuli'
     secrets:

--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '9.1.0'
+modulesync_config_version: '9.3.0'

--- a/.pmtignore
+++ b/.pmtignore
@@ -20,6 +20,7 @@
 /.github/
 /.librarian/
 /Puppetfile.lock
+/Puppetfile
 *.iml
 /.editorconfig
 /.fixtures.yml

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ end
 gem 'rake', :require => false
 gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-puppetversion = ENV['PUPPET_GEM_VERSION'] || '~> 7.24'
+puppetversion = ENV['PUPPET_GEM_VERSION'] || [">= 7.24", "< 9"]
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11",
         "12"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "8",
         "9"
       ]
     },


### PR DESCRIPTION
contains https://github.com/voxpupuli/puppet-alternatives/pull/155 and https://github.com/voxpupuli/puppet-alternatives/pull/153